### PR TITLE
3 add the encore appdashboard behind nginx for security

### DIFF
--- a/api/api-demo.ts
+++ b/api/api-demo.ts
@@ -9,7 +9,7 @@ const username = secret('username');
 const password = secret('password');
 
 export const getAllClients = api(
-  { method: 'GET', path: '/api/clients', expose: true, auth: true },
+  { method: 'GET', path: '/clients', expose: true, auth: true },
   async (): Promise<{ clients: any }> => {
 
     // auth for nginx basic auth
@@ -37,15 +37,29 @@ export const getAllClients = api(
 
     // Return the data in a JSON object
     return { clients };
-  }
+  } 
 );
 
 export const getBootstrapClients = api(
-  { method: 'GET', path: '/api/bsclients', expose: true, auth: true },
+  { method: 'GET', path: '/bsclients', expose: true, auth: true },
   async (): Promise<{ bsClients: any }> => {
 
+    const userLogin = username();
+    const pass = password();
+    const authHeader =
+      'Basic ' + Buffer.from(`${userLogin}:${pass}`).toString('base64');
+
+    // Call the external API
     const url = bootstrap_clients();
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Authorization': authHeader,
+        'Content-type': 'application/json',
+      },
+    });
+
+    
 
     if (!response.ok) {
       throw new Error(`Failed to fetch clients: ${response.statusText}`);
@@ -66,7 +80,7 @@ interface GetClientResponse {
 }
 
 export const getObjectSpec = api(
-  { method: 'GET', path: '/api/objectspecs/:clientId', expose: true, auth: true },
+  { method: 'GET', path: '/objectspecs/:clientId', expose: true, auth: true },
   async ({ clientId }: GetClientRequest): Promise<GetClientResponse> => {
 
     const userLogin = username();
@@ -94,7 +108,7 @@ export const getObjectSpec = api(
 );
 
 export const getClient = api(
-  { method: 'GET', path: '/api/clients/:clientId', expose: true, auth: true },
+  { method: 'GET', path: '/clients/:clientId', expose: true, auth: true },
   async ({ clientId }: GetClientRequest): Promise<GetClientResponse> => {
 
     const userLogin = username();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,14 @@ services:
       - "5684:5684/udp"
 
   encore:
-    image: tony300/encore-leshan-demo:1.0
+    image: tony300/encore-leshan-demo:1.7
     ports:
-      - "4000:8080"
+      - "8080:8080"
     depends_on:
       - demo
       - bootstrap
+    env_file:
+      - .env
     command: ["encore", "run"]
 
   nginx:
@@ -37,3 +39,4 @@ services:
     depends_on:
       - demo
       - bootstrap
+      - encore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  demo:
+  dm:
     build: 
       context: ./leshanDemoServer
       dockerfile: Dockerfile.leshan-server
@@ -19,11 +19,11 @@ services:
       - "5684:5684/udp"
 
   encore:
-    image: tony300/encore-leshan-demo:1.7
+    image: tony300/encore-leshan-demo:2.0.0
     ports:
       - "8080:8080"
     depends_on:
-      - demo
+      - dm
       - bootstrap
     env_file:
       - .env
@@ -37,6 +37,6 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/.htpasswd:/etc/nginx/.htpasswd:ro
     depends_on:
-      - demo
+      - dm
       - bootstrap
       - encore

--- a/infra-config.json
+++ b/infra-config.json
@@ -5,7 +5,7 @@
         "env_name": "development",
         "env_type": "development",
         "cloud": "self-hosted",
-        "base_url": "http://localhost:4000"
+        "base_url": "http://localhost/api"
     },
     "secrets": {
         "username": {

--- a/nginx.conf
+++ b/nginx.conf
@@ -29,7 +29,7 @@ http {
         auth_basic "Restricted Access";
         auth_basic_user_file /etc/nginx/.htpasswd;
 
-            proxy_pass http://demo:8080;
+            proxy_pass http://demo:8080/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -41,6 +41,15 @@ http {
         location /bs/ {
 
             proxy_pass http://bootstrap:8080/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route to encore api's
+        location /api/ {
+            proxy_pass http://encore:8080/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,11 +25,11 @@ http {
         listen 80;
 
         # Route to demo server
-        location / {
+        location /dm/ {
         auth_basic "Restricted Access";
         auth_basic_user_file /etc/nginx/.htpasswd;
 
-            proxy_pass http://demo:8080/;
+            proxy_pass http://dm:8080/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "encore.dev": "^1.46.12"
+        "encore.dev": "^1.46.22"
       },
       "devDependencies": {
         "@types/node": "^20.5.7",
@@ -26,9 +26,9 @@
       }
     },
     "node_modules/encore.dev": {
-      "version": "1.46.12",
-      "resolved": "https://registry.npmjs.org/encore.dev/-/encore.dev-1.46.12.tgz",
-      "integrity": "sha512-reAHAATpykUQpRuzLYz1fwpgpDGBiiBCXe4tAPe8X52nCH6QbXSRyl3IYuX9U4gRpW4IOuZxj8UwkEO/ybFTeA==",
+      "version": "1.46.22",
+      "resolved": "https://registry.npmjs.org/encore.dev/-/encore.dev-1.46.22.tgz",
+      "integrity": "sha512-6DyAAAEtbvryCjWSKqXz2P+JVL5HUuGcIk8kJQoCJOzY1CWuvR97fpfY/TV0xArTP4anQ+2h/gS6I36mVGqhGg==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "encore.dev": "^1.46.20"
+    "encore.dev": "^1.46.22"
   }
 }


### PR DESCRIPTION
In this pr i have put encore endpoint behind nginx and also solved the issue with encore secrets so this also closes #7
I also changed the base url for encore endpoint, in now is localhost/api
I have also changed the dm server address, you now find it at http://localhost/api/dm